### PR TITLE
Feat: Entity

### DIFF
--- a/apps/back/src/app.module.ts
+++ b/apps/back/src/app.module.ts
@@ -5,9 +5,10 @@ import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { PaymentModule } from './payment/payment.module';
 import { CoinModule } from './coin/coin.module';
+import { DatabaseModule } from './database/database.module';
 
 @Module({
-  imports: [UserModule, AuthModule, PaymentModule, CoinModule],
+  imports: [UserModule, AuthModule, PaymentModule, CoinModule, DatabaseModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/back/src/coin/entity/coin.entity.ts
+++ b/apps/back/src/coin/entity/coin.entity.ts
@@ -1,0 +1,17 @@
+import { Payment } from 'src/payment/entity/payment.entity';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+
+@Entity()
+export class Coin {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  shortName: string;
+
+  @OneToMany(type => Payment, (payment) => payment.coin)
+  payments: Payment[];
+}

--- a/apps/back/src/payment/entity/payment.entity.ts
+++ b/apps/back/src/payment/entity/payment.entity.ts
@@ -1,0 +1,43 @@
+import { Coin } from 'src/coin/entity/coin.entity';
+import { User } from 'src/user/entity/user.entity';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, CreateDateColumn, UpdateDateColumn, ManyToOne } from 'typeorm';
+import { PAYMENT_STATUS } from '../enum/payment-status.enum';
+import { PAYMENT_TYPE } from '../enum/payment-type.enum';
+
+@Entity()
+export class Payment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  price: number;
+
+  @Column()
+  account: number;
+
+  @Column({
+    type: "enum",
+    enum: PAYMENT_TYPE,
+    nullable: false
+  })
+  type: string;
+
+  @Column({
+    type: "enum",
+    enum: PAYMENT_STATUS,
+    default: PAYMENT_STATUS.READY
+  })
+  status: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne(type => User, (user) => user.payments)
+  user: User;
+
+  @ManyToOne(type => Coin, (coin) => coin.payments)
+  coin: Coin;
+}

--- a/apps/back/src/payment/enum/payment-status.enum.ts
+++ b/apps/back/src/payment/enum/payment-status.enum.ts
@@ -1,0 +1,5 @@
+export enum PAYMENT_STATUS {
+    READY = "READY",
+    PAID = "PAID",
+    CANCLED = "CANCLED",
+}

--- a/apps/back/src/payment/enum/payment-type.enum.ts
+++ b/apps/back/src/payment/enum/payment-type.enum.ts
@@ -1,0 +1,4 @@
+export enum PAYMENT_TYPE {
+    BUY = "BUY",
+    SALE = "SALE",
+}

--- a/apps/back/src/user/entity/account.entity.ts
+++ b/apps/back/src/user/entity/account.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity()
+export class Account {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  email: string;
+
+  @Column()
+  password: string;
+
+  @ManyToOne(type => User, (user) => user.accounts)
+  user: User;
+}

--- a/apps/back/src/user/entity/user.entity.ts
+++ b/apps/back/src/user/entity/user.entity.ts
@@ -1,0 +1,27 @@
+import { Payment } from 'src/payment/entity/payment.entity';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { Account } from './account.entity';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  loginId: string;
+
+  @Column()
+  password: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  verifiedEmail: string;
+
+  @OneToMany(type => Account, (account) => account.user)
+  accounts: Account[];
+
+  @OneToMany(type => Payment, (payment) => payment.user)
+  payments: Payment[];
+}


### PR DESCRIPTION
### 추가 사항
User, Payment, Coin, Account Entity를 추가합니다.

<img width="642" alt="스크린샷 2022-12-24 오전 11 05 28" src="https://user-images.githubusercontent.com/111725661/209417606-4df18029-f982-461e-8b93-aed460ba29d6.png">

#### 참고 사항
Payment의 경우 결제 타입(구매, 판매), 결제 상턔(대기, 완료, 취소) 값을 enum으로 관리합니다.