### PR TITLE
Feat: Api Formatter

### DIFF
--- a/apps/back/src/app.module.ts
+++ b/apps/back/src/app.module.ts
@@ -1,12 +1,20 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { ChatModule } from './chat/chat.module';
+import { ResponseFormatInterceptor } from './common/interceptor/response.interceptor';
 
 @Module({
   imports: [ChatModule, AuthModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ResponseFormatInterceptor,
+    },
+  ],
 })
 export class AppModule {}

--- a/apps/back/src/common/interceptor/response.interceptor.ts
+++ b/apps/back/src/common/interceptor/response.interceptor.ts
@@ -1,0 +1,27 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiResponse } from '../interface/response.interface';
+
+@Injectable()
+export class ResponseFormatInterceptor<T>
+  implements NestInterceptor<T, ApiResponse<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<ApiResponse<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        statusCode: context.switchToHttp().getResponse().statusCode,
+        data: data,
+        message: data.message || '',
+      })),
+    );
+  }
+}

--- a/apps/back/src/common/interface/response.interface.ts
+++ b/apps/back/src/common/interface/response.interface.ts
@@ -1,0 +1,5 @@
+export interface ApiResponse<T> {
+  statusCode: number;
+  data: T;
+  message: string;
+}


### PR DESCRIPTION
### 추가 사항
API response를 통일된 포맷으로 전달하는 ResponsFormatInterceptor를 추가합니다.

포맷은 다음과 같습니다.
```
{
  statusCode: number;
  data: T; --> generic
  message: string  // error 메세지 반환용
}
```

#### 참고 이미지
<img width="231" alt="스크린샷 2023-01-18 오후 10 56 18" src="https://user-images.githubusercontent.com/111725661/213189846-9c207b3f-4fed-4d8b-8528-2fdcca488ee2.png">
