### PR TITLE
docker-compose-error-fix

### DIFF
--- a/apps/back/src/database/database.providers.ts
+++ b/apps/back/src/database/database.providers.ts
@@ -7,10 +7,10 @@ export const databaseProviders = [
     useFactory: async () => {
       const dataSource = new DataSource({
         type: 'mysql',
-        host: process.env.DB_HOST,
+        host: process.env.MYSQL_CONTAINER_NAME,
         port: 3306,
         username: 'root',
-        password: 'root',
+        password: process.env.MYSQL_ROOT_PASSWORD,
         database: 'downchat',
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
         synchronize: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
   #   restart: always
   #   ports:
   #     - 3000:3000
-  #   networks:
-  #     - app_network
 
   api:
     depends_on:
@@ -22,14 +20,12 @@ services:
       dockerfile: ./apps/back/api.Dockerfile
     restart: always
     environment:
-      DB_HOST: db
+      DB_HOST: mysql
       GOOGLE_USERINFO_API: https://www.googleapis.com/oauth2/v1/userinfo
       JWT_SECRET: DOWNTALK_SECRET
     ports:
       - 4000:4000
-    networks:
-      - app_network
-
+    
   chat:
     depends_on:
       - mysql
@@ -40,12 +36,10 @@ services:
       dockerfile: ./apps/back/chat.Dockerfile
     restart: always
     environment:
-      DB_HOST: db
+      DB_HOST: mysql
     ports:
       - 4001:4001
-    networks:
-      - app_network
-
+    
   mysql:
     image: mysql:8.0
     container_name: mysql
@@ -58,9 +52,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: downchat
-    networks:
-      - app_network
-
+    
   mongo:
     image: mongo
     container_name: mongo
@@ -84,15 +76,7 @@ services:
     ports:
       - "8080:80"
     environment:
-      PMA_HOST: db
-    networks:
-      - app_network
-
-# Define a network, which allows containers to communicate
-# with each other, by using their container name as a hostname
-networks:
-  app_network:
-    external: true
-
+      PMA_HOST: mysql
+    
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: "3.2"
 
 services:
-  # web:
-  #   container_name: web
-  #   build:
-  #     context: .
-  #     dockerfile: ./apps/front/Dockerfile
-  #   restart: always
-  #   ports:
-  #     - 3000:3000
-
   api:
     depends_on:
       - mysql
@@ -20,7 +11,8 @@ services:
       dockerfile: ./apps/back/api.Dockerfile
     restart: always
     environment:
-      DB_HOST: mysql
+      MYSQL_CONTAINER_NAME: mysql
+      MYSQL_ROOT_PASSWORD: pass
       GOOGLE_USERINFO_API: https://www.googleapis.com/oauth2/v1/userinfo
       JWT_SECRET: DOWNTALK_SECRET
     ports:
@@ -36,7 +28,8 @@ services:
       dockerfile: ./apps/back/chat.Dockerfile
     restart: always
     environment:
-      DB_HOST: mysql
+      MYSQL_CONTAINER_NAME: mysql
+      MYSQL_ROOT_PASSWORD: pass
     ports:
       - 4001:4001
     
@@ -48,9 +41,9 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - db_data:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: pass
       MYSQL_DATABASE: downchat
     
   mongo:
@@ -60,16 +53,14 @@ services:
     ports:
       - 27017:27017
     volumes:
-      - db_data:/var/lib/mongo
+      - mongo_data:/var/lib/mongo
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=root
-      - MONGO_INITDB_ROOT_PASSWORD=1234
-      - MONGO_INITDB_DATABASE=mydb
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: pass
 
   phpmyadmin:
     depends_on:
       - mysql
-      - mongo
     image: phpmyadmin/phpmyadmin
     container_name: phpmyadmin
     restart: always
@@ -77,6 +68,7 @@ services:
       - "8080:80"
     environment:
       PMA_HOST: mysql
-    
+
 volumes:
-  db_data:
+  mysql_data:
+  mongo_data:

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,1 +1,4 @@
-docker-compose build && docker-compose up
+#!/bin/bash
+DIR="$( cd "$( dirname "$0" )" && pwd -P )"
+cd ./apps/back && yarn install && yarn build 
+cd $DIR && docker-compose build && docker-compose up

--- a/local_run.sh
+++ b/local_run.sh
@@ -1,1 +1,1 @@
-docker-compose build db phpmyadmin && docker-compose up db phpmyadmin
+docker-compose build mysql phpmyadmin mongo && docker-compose up mysql phpmyadmin mongo

--- a/local_run.sh
+++ b/local_run.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 docker-compose build mysql phpmyadmin mongo && docker-compose up mysql phpmyadmin mongo


### PR DESCRIPTION
## 작업 내용 (Content)
1. 컨테이너 이름 변경 
=> 기존 mysql에 service container 이름이 db -> mysql로 변경됨에 따라
mysql을 사용하는 container에 DB_HOST 값 변경

2. networks 생성 코드 삭제
=> docker-compose로 컨테이너 실행시 default network가 존재해서 현재 프로젝트상 커스텀 네트워크가 필요할 것으로
보이지 않습니다. 커스텀 네트워크 사용시 해당 네트워크를 사용하기위해 로컬에서 추가적으로 생성해줘야하는 번거로움이 있는 문제도
있습니다. 

프론트 서버 실행후 테스트 진행시 docker_run.sh 실행이후 진행해주시면 됩니다.
네트워크 떄문에 에러나는 부분은 해결했지만, 하나 더 문제를 일으킬 여지가 있는 부분은 백엔드 코드를
build하지 않고 실행하는 경우가 있습니다.

dockerfile자체가 build한 dist 폴더에 main.js를 기준으로 실행되기떄문에
현재 테스트 진행시에는 pull받은 이후 /apps/back 안에서 yarn build or npm run build 실행 이후 실행 해주시기 바랍니다.
또한 새로운 라이브러리 추가시 yarn install or npm install을 해주셔야 합니다.

build를 매번 해야하는 부분은 homes랑 상의를 해봐야할 듯 한데, 일요일날 말씀드리겠습니다!

## 링크 (Links)
docker-compose default network : https://www.daleseo.com/docker-compose-networks/

## 희망 리뷰 완료 일 (Expected due date)
2022-02-06 Mon
