### PR TITLE
Modify: Auth Logic & Feat: MyProfile

### DIFF
--- a/apps/back/src/auth/auth.service.ts
+++ b/apps/back/src/auth/auth.service.ts
@@ -60,18 +60,17 @@ export class AuthService {
     return true;
   }
 
-  async loginUser(email: string) {
-    const row = await this.userRepository.findOne({
+  async loginUser(email: string): Promise<User> {
+    return this.userRepository.findOne({
       where: {
         email,
       },
     });
-
-    return row ? true : false;
   }
 
   async generateToken(email: string) {
-    const ci = await this.generateCi(email);
+    const user = await this.loginUser(email);
+    const ci = await this.generateCi(user.id);
     const accessToken = this.jwtService.sign(
       { ci },
       {
@@ -91,24 +90,28 @@ export class AuthService {
     return data;
   }
 
-  async generateCi(email: string) {
-    const cipher = createCipheriv(algorithm, Buffer.from(key), iv);
-    const encrypted = cipher.update(email);
+  async generateCi(userId: number) {
+    // const cipher = createCipheriv(algorithm, Buffer.from(key), iv);
+    // const encrypted = cipher.update(email);
 
-    return (
-      iv.toString('hex') +
-      ':' +
-      Buffer.concat([encrypted, cipher.final()]).toString('hex')
-    );
+    // return (
+    //   iv.toString('hex') +
+    //   ':' +
+    //   Buffer.concat([encrypted, cipher.final()]).toString('hex')
+    // );
+
+    return userId;
   }
 
   async verifyCi(ci: any) {
-    const textParts = ci.split(':');
-    const iv = Buffer.from(textParts.shift(), 'hex');
-    const encryptedText = Buffer.from(textParts.join(':'), 'hex');
-    const decipher = createDecipheriv('aes-256-cbc', Buffer.from(key), iv);
-    const decrypted = decipher.update(encryptedText);
+    // const textParts = ci.split(':');
+    // const iv = Buffer.from(textParts.shift(), 'hex');
+    // const encryptedText = Buffer.from(textParts.join(':'), 'hex');
+    // const decipher = createDecipheriv('aes-256-cbc', Buffer.from(key), iv);
+    // const decrypted = decipher.update(encryptedText);
 
-    return Buffer.concat([decrypted, decipher.final()]).toString();
+    // return Buffer.concat([decrypted, decipher.final()]).toString();
+
+    return ci;
   }
 }

--- a/apps/back/src/auth/auth.startegy.ts
+++ b/apps/back/src/auth/auth.startegy.ts
@@ -17,7 +17,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    const email = await this.authService.verifyCi(payload.ci);
-    return email;
+    const userId = await this.authService.verifyCi(payload.ci);
+    return { id: userId };
   }
 }

--- a/apps/back/src/user/user.controller.ts
+++ b/apps/back/src/user/user.controller.ts
@@ -1,6 +1,16 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UserService } from './user.service';
 
+@UseGuards(JwtAuthGuard)
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
@@ -17,5 +27,11 @@ export class UserController {
   @Get('/:userId/profile')
   async getProfile(@Param('userId') userId: number) {
     return this.userService.getProfile(userId);
+  }
+
+  @Get('/profile')
+  async getMyProfile(@Req() req: { user: { id: number } }) {
+    console.log(req.user);
+    return this.userService.getProfile(req.user.id);
   }
 }


### PR DESCRIPTION
## 작업 내용 (Content)

- MyProfile을 조회하는 API를 추가합니다. GET /users/profile
  -  타인 조회는 GET /users/:userId/profile입니다.
  - response 결과는 동일합니다.

- Ci generate 로직은 주석처리합니다. (정확한 내용 및 플로우를 파악하지 못해 후처리 예정입니다.)

## 고려 및 참고 사항
- Ci 작업의 경우 토큰 내부값을 암호화 처리 하는 과정인데 해당 과정의 필요성이 있는지 얘기가 필요합니다.

## 링크 (Links) - 필요 시 기재


## Merge 전 필요 작업 (Checklist before merge)
- [x] Postman에서 client에서 구글 로그인을 통해 발급받은 토큰으로 profile 조회가 되는지 확인합니다.
- [x] Bearer Token에 대한 API Response Example을 추가합니다.  (내 프로필 조회)

## 희망 리뷰 완료 일 (Expected due date)

202X. X. X. Wed
