### PR TITLE
Fix: searchUsers limit, offset default value

### DIFF
--- a/apps/back/src/user/user.controller.ts
+++ b/apps/back/src/user/user.controller.ts
@@ -8,10 +8,13 @@ export class UserController {
   @Get()
   async searchUsers(
     @Query('searchKey') searchKey: string,
-    @Query('limit', ParseIntPipe) limit: number,
-    @Query('offset', ParseIntPipe) offset: number,
+    @Query('limit') limit: string = '10',
+    @Query('offset') offset: string = '0',
   ) {
-    return this.userService.searchUsers(searchKey, limit, offset);
+    const parsedLimit = parseInt(limit, 10);
+    const parsedOffset = parseInt(offset, 10);
+
+    return this.userService.searchUsers(searchKey, parsedLimit, parsedOffset);
   }
 
   @Get('/:userId/profile')


### PR DESCRIPTION
## 작업 내용 (Content)

- 사용자 검색시 limit, offset의 값을 default로 가져갈 수 있도록 수정합니다.
  - limit = 10, offset = 0

## 고려 및 참고 사항

## 링크 (Links) - 필요 시 기재

## Merge 전 필요 작업 (Checklist before merge)
- [x] postman에서 limit, offset 값 없이 실행되는지 확인합니다.

## 희망 리뷰 완료 일 (Expected due date)

202X. X. X. Wed
